### PR TITLE
JAX version of DQN

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     additional_dependencies: ["toml"]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910-1
+  rev: v1.10.0
   hooks:
   - id: mypy
     args: ["--check-untyped-defs", "--ignore-missing-imports"]

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build:
 	hatch build
 
 install:
-	pip install .
+	pip install -e .
 
 clean:
 	rm -rf dist
@@ -39,7 +39,7 @@ isort:
 	hatch run test:isort
 
 mypy:
-	mypy rl_2048 tests --check-untyped-defs
+	mypy rl_2048 tests --check-untyped-defs --ignore-missing-imports
 
 bandit:
 	bandit -c pyproject.toml -r .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,14 @@ readme = "README.md"
 license = "MIT"
 dynamic = ["version"]
 requires-python = ">= 3.8"
-dependencies = ["pygame>=2.5.2", "torch>=2.3.0", "matplotlib>=3.8.4"]
+dependencies = [
+    "pygame>=2.5.2",
+    "torch>=2.3.0",
+    "matplotlib>=3.8.4",
+    "jax>=0.4.16",
+    "jaxlib>=0.4.16",
+    "flax>=0.8.3"
+]
 authors = [{ name = "Fang-Lin He", email = "fanglin.he.ms@gmail.com" }]
 classifiers = [
     "Development Status :: 1 - Planning",

--- a/rl_2048/DQN/replay_memory.py
+++ b/rl_2048/DQN/replay_memory.py
@@ -61,7 +61,7 @@ class ReplayMemory:
 
     def sample(self, batch_size: int) -> Batch:
         random_indices = random.sample(list(range(len(self))), batch_size)
-        return Batch(
+        batch = Batch(
             torch.tensor([self.states[i] for i in random_indices]),
             torch.tensor(
                 [self.actions[i] for i in random_indices], dtype=torch.int64
@@ -72,6 +72,7 @@ class ReplayMemory:
                 [self.games_over[i] for i in random_indices], dtype=torch.bool
             ).view((-1, 1)),
         )
+        return batch
 
     def __len__(self):
         return len(self.states)

--- a/rl_2048/bin/playRL2048_dqn.py
+++ b/rl_2048/bin/playRL2048_dqn.py
@@ -193,15 +193,15 @@ def train(
         memory_capacity=20000,
         gamma=0.99,
         batch_size=128,
-        lr=1e-5,
-        lr_decay_milestones=[15000, 30000, 50000, 70000],
+        lr=5e-3,
+        lr_decay_milestones=[1500, 3000, 5000, 7000],
         lr_gamma=0.1,
-        eps_start=0.7,
+        eps_start=0.9,
         eps_end=0.05,
-        eps_decay=10000,
+        eps_decay=1500,
         TAU=0.005,
-        save_network_steps=2000,
-        print_loss_steps=500,
+        save_network_steps=200,
+        print_loss_steps=50,
     )
     reward_norm_factor: int = 256  # reward / reward_norm_factor for value function
 
@@ -332,7 +332,22 @@ def eval_dqn(
     policy_net = load_nets(network_version, in_features, out_features).policy_net
 
     policy_net.eval()
-    policy_net.load_state_dict(torch.load(trained_net_path))
+    try:
+        state_dict = torch.load(trained_net_path)
+    except FileNotFoundError:
+        try:
+            print(f"Loading model from {trained_net_path} failed.")
+            if "rl_2048/" in trained_net_path:
+                search_in_parent_path: str = trained_net_path.replace("rl_2048/", "")
+                print(f"Try to load model from {search_in_parent_path}")
+                state_dict = torch.load(search_in_parent_path)
+            else:
+                raise
+        except FileNotFoundError:
+            print(f"Loading model from {search_in_parent_path} still failed.")
+            raise
+
+    policy_net.load_state_dict(state_dict)
 
     move_failure = 0
     date_time_str = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/rl_2048/bin/playRL2048_jax_dqn.py
+++ b/rl_2048/bin/playRL2048_jax_dqn.py
@@ -24,9 +24,6 @@ from rl_2048.tile_plotter import PlotProperties, TilePlotter
 
 PREDEFINED_NETWORKS: Set[str] = {
     "layers_1024_512_256",
-    # "layers_512_512_residual_0_128",
-    # "layers_512_256_128_residual_0_64_32",
-    # "layers_512_256_256_residual_0_128_128",
 }
 
 
@@ -92,14 +89,6 @@ def make_state_from_grids(tile: Tile) -> Sequence[float]:
     return [float(value) for row in tile.grids for value in row]
 
 
-# def make_state_one_hot(tile: Tile) -> Array:
-#     def one_hot(v: int, size: int = 16) -> Sequence[float]:
-#         loc = int(math.log2(float(v))) if v > 0 else 0
-#         return [1.0 if i == loc else 0.0 for i in range(size)]
-
-#     return [float(one_hot(value)) for row in tile.grids for value in row]
-
-
 INVALID_MOVEMENT_REWARD: float = -(2**8)
 GAME_OVER_REWARD: float = -(2**12)
 
@@ -117,21 +106,10 @@ def write_json(move_failures, total_scores, max_grids, total_rewards, filepath: 
         shutil.move(tmp_file, filepath)
 
 
-def load_net(network_version: str, in_features: int, out_features: int) -> nn.Module:
+def load_net(network_version: str, _in_features: int, out_features: int) -> nn.Module:
     hidden_layers: Tuple[int, ...]
-    # residual_mid_feature_sizes: List[int]
     if network_version == "layers_1024_512_256":
         hidden_layers = (1024, 512, 256)
-        # residual_mid_feature_sizes = []
-    # elif network_version == "layers_512_512_residual_0_128":
-    #     hidden_layers = (512, 512)
-    #     residual_mid_feature_sizes = [0, 128]
-    # elif network_version == "layers_512_256_128_residual_0_64_32":
-    #     hidden_layers = (512, 256, 128)
-    #     residual_mid_feature_sizes = [0, 64, 32]
-    # elif network_version == "layers_512_256_256_residual_0_128_128":
-    #     hidden_layers = (512, 256, 256)
-    #     residual_mid_feature_sizes = [0, 128, 128]
     else:
         raise NameError(
             f"Network version {network_version} not in {PREDEFINED_NETWORKS}."
@@ -173,14 +151,14 @@ def train(
         gamma=0.99,
         batch_size=128,
         lr=5e-3,
-        lr_decay_milestones=[1500, 3000, 5000, 7000],
+        lr_decay_milestones=[15000, 30000, 50000, 70000],
         lr_gamma=0.1,
         eps_start=0.9,
         eps_end=0.05,
-        eps_decay=1500,
+        eps_decay=15000,
         TAU=0.005,
-        save_network_steps=200,
-        print_loss_steps=50,
+        save_network_steps=2000,
+        print_loss_steps=500,
     )
     reward_norm_factor: int = 256  # reward / reward_norm_factor for value function
     rng: Array = jrandom.key(0)
@@ -228,8 +206,6 @@ def train(
             else:  # action == Action.RIGHT
                 move_result = game_engine.move_right()
 
-            # move_result = game_engine.move(action)
-
             if move_result.suc:
                 suc_move_statistics[action] += 1
                 # print(tile)
@@ -240,10 +216,7 @@ def train(
                 reward += INVALID_MOVEMENT_REWARD
 
             if game_engine.game_is_over:
-                reward += GAME_OVER_REWARD  # + tile.max_grid())
-
-            # Normalize reward by max grid
-            # reward /= tile.max_grid()
+                reward += GAME_OVER_REWARD
 
             next_state = flat_one_hot(tile.flattened(), 16)
             total_reward += reward
@@ -261,7 +234,6 @@ def train(
                 total_rewards.append(total_reward)
                 total_reward = 0.0
 
-            # dqn.push_transition_and_optimize_automatically(transition, output_net_dir)
             dqn.push_transition(transition)
             new_collect_count += 1
             if new_collect_count >= training_params.batch_size * 50:
@@ -307,150 +279,9 @@ def train(
     print(f"See results in {output_json_fn}.")
 
 
-# def eval_dqn(
-#     show_board: bool,
-#     print_results: bool,
-#     output_json_prefix: str,
-#     max_iters: int,
-#     trained_net_path: str,
-#     network_version: str,
-# ):
-#     tile: Tile = Tile(width=4, height=4)
-#     plot_properties: PlotProperties = PlotProperties(fps=60, delay_after_plot=50)
-#     plotter: TilePlotter = TilePlotter(tile, plot_properties)
-#     game_engine: GameEngine = GameEngine(tile)
-
-#     move_failures: List[int] = []
-#     total_scores: List[int] = []
-#     max_grids: List[int] = []
-
-#     # DQN part
-#     in_features: int = tile.width * tile.height * 16
-#     out_features: int = len(Action)
-#     policy_net = load_net(network_version, in_features, out_features).policy_net
-
-#     policy_net.eval()
-#     try:
-#         state_dict = torch.load(trained_net_path)
-#     except FileNotFoundError:
-#         try:
-#             print(f"Loading model from {trained_net_path} failed.")
-#             if "rl_2048/" in trained_net_path:
-#                 search_in_parent_path: str = trained_net_path.replace("rl_2048/", "")
-#                 print(f"Try to load model from {search_in_parent_path}")
-#                 state_dict = torch.load(search_in_parent_path)
-#             else:
-#                 raise
-#         except FileNotFoundError:
-#             print(f"Loading model from {search_in_parent_path} still failed.")
-#             raise
-
-#     policy_net.load_state_dict(state_dict)
-
-#     move_failure = 0
-#     date_time_str = datetime.now().strftime("%Y%m%d_%H%M%S")
-#     output_json_fn = f"{output_json_prefix}_{date_time_str}.json"
-
-#     iter = 0
-#     start_time = time.time()
-#     cur_state: Sequence[float] = make_state_one_hot(tile)
-
-#     action_candidates: List[Action] = []
-#     inf_times = []
-
-#     prev_score: int = game_engine.score
-#     score_not_increasing_count: int = 0
-#     while max_iters < 0 or iter < max_iters:
-#         for event in pygame.event.get():
-#             if event.type == pygame.QUIT:
-#                 pygame.quit()
-#                 exit()
-
-#             if event.type == pygame.KEYUP and event.key == pygame.K_r:
-#                 game_engine.reset()
-#                 prev_score = game_engine.score
-
-#         if not game_engine.game_is_over:
-#             start_inf_time = time.time()
-#             policy_net_output = DQN.infer_action(policy_net, cur_state)
-#             inf_times.append(time.time() - start_inf_time)
-#             action: Action = policy_net_output.action
-
-#             move_result: MoveResult = game_engine.move(action)
-#             if move_result.suc:
-#                 game_engine.generate_new()
-#             else:
-#                 move_failure += 1
-#                 # action_candidates = [
-#                 #     candidate for candidate in Action if candidate != action
-#                 # ]
-#                 # shuffle(action_candidates)
-#                 # for action in action_candidates:
-#                 #     move_result = game_engine.move(action)
-#                 #     if move_result.suc:
-#                 #         break
-#                 #     move_failure += 1
-#                 # if not move_result.suc:
-#                 #     raise ValueError("Game is not over yet but all actions failed")
-
-#             if game_engine.score == prev_score:
-#                 score_not_increasing_count += 1
-#             else:
-#                 score_not_increasing_count = 0
-#             prev_score = game_engine.score
-
-#             cur_state = make_state_one_hot(tile)
-
-#             if show_board:
-#                 plotter.plot(game_engine.score)
-#             else:
-#                 tile.reset_animation_grids()
-
-#             if game_engine.game_is_over:
-#                 iter += 1
-#                 if show_board:
-#                     plotter.plot_game_over()
-#                 move_failures.append(move_failure)
-#                 move_failure = 0
-#                 max_grids.append(tile.max_grid())
-#                 total_scores.append(game_engine.score)
-#                 if print_results:
-#                     print(f"Move failures: {move_failures}")
-#                     print(f"Total scores: {total_scores}")
-#                     print(f"Max grids: {max_grids}")
-
-#                 if iter % 10 == 0:
-#                     write_json(
-#                         move_failures,
-#                         total_scores,
-#                         max_grids,
-#                         [],  # total_rewards,
-#                         output_json_fn,
-#                     )
-#                 game_engine.reset()
-
-#     write_json(move_failures, total_scores, max_grids, [], output_json_fn)
-#     elapsed_sec = time.time() - start_time
-#     print(
-#         f"Done running {max_iters} times of experiments in {round(elapsed_sec * 1000.0)} millisecond(s)."
-#     )
-#     print(
-#         f"Average inference time: {(sum(inf_times) / len(inf_times)) * 1000.0} millisecond(s)"
-#     )
-#     print(f"See results in {output_json_fn}.")
-
-
 def main():
     args = parse_args()
     if args.eval:
-        # eval_dqn(
-        #     args.show_board,
-        #     args.print_results,
-        #     args.output_json_prefix,
-        #     args.max_iters,
-        #     args.trained_net_path,
-        #     args.network_version,
-        # )
         pass
     else:
         train(

--- a/rl_2048/bin/playRL2048_jax_dqn.py
+++ b/rl_2048/bin/playRL2048_jax_dqn.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import os
+import shutil
+import time
+from collections import defaultdict
+from datetime import datetime
+from typing import Dict, List, Sequence, Set, Tuple
+
+import pygame
+from flax import linen as nn
+from jax import Array
+from jax import random as jrandom
+
+from rl_2048.game_engine import GameEngine
+from rl_2048.jax_dqn.dqn import DQN, TrainingParameters
+from rl_2048.jax_dqn.net import Net
+from rl_2048.jax_dqn.replay_memory import Action, Transition
+from rl_2048.jax_dqn.utils import flat_one_hot
+from rl_2048.tile import Tile
+from rl_2048.tile_plotter import PlotProperties, TilePlotter
+
+PREDEFINED_NETWORKS: Set[str] = {
+    "layers_1024_512_256",
+    # "layers_512_512_residual_0_128",
+    # "layers_512_256_128_residual_0_64_32",
+    # "layers_512_256_256_residual_0_128_128",
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="PlayRL2048Random", description="Play 2048 with random actions"
+    )
+    parser.add_argument(
+        "--show_board",
+        action="store_true",
+        help="Show the procedure of the game",
+    )
+    parser.add_argument(
+        "--print_results",
+        action="store_true",
+        help="Print results, like scores, failure times, etc.",
+    )
+    parser.add_argument(
+        "--output_json_prefix",
+        default="Experiments/jax_dqn",
+        help="Prefix of output json file",
+    )
+    parser.add_argument(
+        "--output_net_prefix",
+        default="TrainedNetworks/jax_dqn",
+        help="Prefix of output json file",
+    )
+    parser.add_argument(
+        "--max_iters",
+        default=1000,
+        type=int,
+        help="Max iterations of experiments; set it to negative value to run infinitely",
+    )
+    parser.add_argument(
+        "--trained_net_path",
+        type=str,
+        default="",
+        help="Path to pre-trained or trained network to train / play DQN. If in train mode, "
+        "the weights are initialized from pre-trained model.",
+    )
+    parser.add_argument(
+        "--eval",
+        action="store_true",
+        help="Train mode or eval mode. If eval mode, --trained_net_path must be specified.",
+    )
+    parser.add_argument(
+        "--network_version",
+        default="layers_1024_512_256",
+        type=str,
+        help="Network version which maps to certain network structure. See `PREDEFINED_NETWORKS` for the names",
+    )
+    args = parser.parse_args()
+
+    if args.eval and args.trained_net_path == "":
+        raise ValueError(
+            "`--eval` is specified, so `--trained_net_path` must be specified"
+        )
+
+    return args
+
+
+def make_state_from_grids(tile: Tile) -> Sequence[float]:
+    return [float(value) for row in tile.grids for value in row]
+
+
+# def make_state_one_hot(tile: Tile) -> Array:
+#     def one_hot(v: int, size: int = 16) -> Sequence[float]:
+#         loc = int(math.log2(float(v))) if v > 0 else 0
+#         return [1.0 if i == loc else 0.0 for i in range(size)]
+
+#     return [float(one_hot(value)) for row in tile.grids for value in row]
+
+
+INVALID_MOVEMENT_REWARD: float = -(2**8)
+GAME_OVER_REWARD: float = -(2**12)
+
+
+def write_json(move_failures, total_scores, max_grids, total_rewards, filepath: str):
+    output_json = {
+        "move_failures": move_failures,
+        "total_scores": total_scores,
+        "max_grids": max_grids,
+        "total_rewards": total_rewards,
+    }
+    tmp_file = f"{filepath}.tmp"
+    with open(tmp_file, "w") as fid:
+        json.dump(output_json, fid)
+        shutil.move(tmp_file, filepath)
+
+
+def load_net(network_version: str, in_features: int, out_features: int) -> nn.Module:
+    hidden_layers: Tuple[int, ...]
+    # residual_mid_feature_sizes: List[int]
+    if network_version == "layers_1024_512_256":
+        hidden_layers = (1024, 512, 256)
+        # residual_mid_feature_sizes = []
+    # elif network_version == "layers_512_512_residual_0_128":
+    #     hidden_layers = (512, 512)
+    #     residual_mid_feature_sizes = [0, 128]
+    # elif network_version == "layers_512_256_128_residual_0_64_32":
+    #     hidden_layers = (512, 256, 128)
+    #     residual_mid_feature_sizes = [0, 64, 32]
+    # elif network_version == "layers_512_256_256_residual_0_128_128":
+    #     hidden_layers = (512, 256, 256)
+    #     residual_mid_feature_sizes = [0, 128, 128]
+    else:
+        raise NameError(
+            f"Network version {network_version} not in {PREDEFINED_NETWORKS}."
+        )
+
+    policy_net: nn.Module = Net(hidden_layers, out_features, nn.relu)
+    return policy_net
+
+
+def train(
+    show_board: bool,
+    print_results: bool,
+    output_json_prefix: str,
+    output_net_prefix: str,
+    max_iters: int,
+    network_version: str,
+    pre_trained_net_path: str = "",
+):
+    tile: Tile = Tile(width=4, height=4)
+    plot_properties: PlotProperties = PlotProperties(fps=60, delay_after_plot=50)
+    plotter: TilePlotter = TilePlotter(tile, plot_properties)
+    game_engine: GameEngine = GameEngine(tile)
+
+    move_failures: List[int] = []
+    total_scores: List[int] = []
+    max_grids: List[int] = []
+
+    # DQN part
+    in_features: int = tile.width * tile.height * 16
+    out_features: int = len(Action)
+    policy_net = load_net(
+        network_version,
+        in_features,
+        out_features,
+    )
+
+    training_params = TrainingParameters(
+        memory_capacity=20000,
+        gamma=0.99,
+        batch_size=128,
+        lr=5e-3,
+        lr_decay_milestones=[1500, 3000, 5000, 7000],
+        lr_gamma=0.1,
+        eps_start=0.9,
+        eps_end=0.05,
+        eps_decay=1500,
+        TAU=0.005,
+        save_network_steps=200,
+        print_loss_steps=50,
+    )
+    reward_norm_factor: int = 256  # reward / reward_norm_factor for value function
+    rng: Array = jrandom.key(0)
+
+    move_failure = 0
+    date_time_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_json_fn = f"{output_json_prefix}_{date_time_str}.json"
+    output_net_dir = (
+        f"{output_net_prefix}/{os.path.basename(output_json_prefix)}_{date_time_str}"
+    )
+    os.makedirs(output_net_dir)
+
+    dqn = DQN(in_features, policy_net, output_net_dir, training_params, rng)
+    if pre_trained_net_path != "":
+        dqn.load_model(pre_trained_net_path)
+
+    iter = 0
+    start_time = time.time()
+    cur_state: Sequence[float] = flat_one_hot(tile.flattened(), 16)
+    next_state: Sequence[float] = cur_state
+    total_rewards: List[float] = []
+    suc_move_statistics: Dict[Action, int] = defaultdict(int)
+    total_reward: float = 0.0
+
+    new_collect_count: int = 0
+    while iter < max_iters:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                exit()
+
+            if event.type == pygame.KEYUP and event.key == pygame.K_r:
+                game_engine.reset()
+
+        if not game_engine.game_is_over:
+            action: Action = dqn.get_action_epsilon_greedy(cur_state)
+            reward: float = 0.0
+
+            if action == Action.UP:
+                move_result = game_engine.move_up()
+            elif action == Action.DOWN:
+                move_result = game_engine.move_down()
+            elif action == Action.LEFT:
+                move_result = game_engine.move_left()
+            else:  # action == Action.RIGHT
+                move_result = game_engine.move_right()
+
+            # move_result = game_engine.move(action)
+
+            if move_result.suc:
+                suc_move_statistics[action] += 1
+                # print(tile)
+                game_engine.generate_new()
+                reward += move_result.score
+            else:
+                move_failure += 1
+                reward += INVALID_MOVEMENT_REWARD
+
+            if game_engine.game_is_over:
+                reward += GAME_OVER_REWARD  # + tile.max_grid())
+
+            # Normalize reward by max grid
+            # reward /= tile.max_grid()
+
+            next_state = flat_one_hot(tile.flattened(), 16)
+            total_reward += reward
+
+            transition = Transition(
+                state=cur_state,
+                action=action,
+                next_state=next_state,
+                reward=reward / reward_norm_factor,
+                game_over=game_engine.game_is_over,
+            )
+            cur_state = next_state[:]
+
+            if game_engine.game_is_over:
+                total_rewards.append(total_reward)
+                total_reward = 0.0
+
+            # dqn.push_transition_and_optimize_automatically(transition, output_net_dir)
+            dqn.push_transition(transition)
+            new_collect_count += 1
+            if new_collect_count >= training_params.batch_size * 50:
+                for _ in range(50):
+                    _loss = dqn.optimize_model()
+                new_collect_count = 0
+
+            if show_board:
+                plotter.plot(game_engine.score)
+            elif move_result.suc:
+                tile.reset_animation_grids()
+            if print_results:
+                print(".\r")
+            if game_engine.game_is_over:
+                iter += 1
+                if show_board:
+                    plotter.plot_game_over()
+                move_failures.append(move_failure)
+                move_failure = 0
+                max_grids.append(tile.max_grid())
+                total_scores.append(game_engine.score)
+                if print_results:
+                    print(f"Move failures: {move_failures}")
+                    print(f"Total scores: {total_scores}")
+                    print(f"Max grids: {max_grids}")
+                    print(f"total_rewards: {total_rewards}")
+
+                if iter % 10 == 0:
+                    write_json(
+                        move_failures,
+                        total_scores,
+                        max_grids,
+                        total_rewards,
+                        output_json_fn,
+                    )
+                game_engine.reset()
+
+    write_json(move_failures, total_scores, max_grids, total_rewards, output_json_fn)
+    elapsed_sec = time.time() - start_time
+    print(
+        f"Done running {max_iters} times of experiments in {round(elapsed_sec * 1000.0)} millisecond(s)."
+    )
+    print(f"See results in {output_json_fn}.")
+
+
+# def eval_dqn(
+#     show_board: bool,
+#     print_results: bool,
+#     output_json_prefix: str,
+#     max_iters: int,
+#     trained_net_path: str,
+#     network_version: str,
+# ):
+#     tile: Tile = Tile(width=4, height=4)
+#     plot_properties: PlotProperties = PlotProperties(fps=60, delay_after_plot=50)
+#     plotter: TilePlotter = TilePlotter(tile, plot_properties)
+#     game_engine: GameEngine = GameEngine(tile)
+
+#     move_failures: List[int] = []
+#     total_scores: List[int] = []
+#     max_grids: List[int] = []
+
+#     # DQN part
+#     in_features: int = tile.width * tile.height * 16
+#     out_features: int = len(Action)
+#     policy_net = load_net(network_version, in_features, out_features).policy_net
+
+#     policy_net.eval()
+#     try:
+#         state_dict = torch.load(trained_net_path)
+#     except FileNotFoundError:
+#         try:
+#             print(f"Loading model from {trained_net_path} failed.")
+#             if "rl_2048/" in trained_net_path:
+#                 search_in_parent_path: str = trained_net_path.replace("rl_2048/", "")
+#                 print(f"Try to load model from {search_in_parent_path}")
+#                 state_dict = torch.load(search_in_parent_path)
+#             else:
+#                 raise
+#         except FileNotFoundError:
+#             print(f"Loading model from {search_in_parent_path} still failed.")
+#             raise
+
+#     policy_net.load_state_dict(state_dict)
+
+#     move_failure = 0
+#     date_time_str = datetime.now().strftime("%Y%m%d_%H%M%S")
+#     output_json_fn = f"{output_json_prefix}_{date_time_str}.json"
+
+#     iter = 0
+#     start_time = time.time()
+#     cur_state: Sequence[float] = make_state_one_hot(tile)
+
+#     action_candidates: List[Action] = []
+#     inf_times = []
+
+#     prev_score: int = game_engine.score
+#     score_not_increasing_count: int = 0
+#     while max_iters < 0 or iter < max_iters:
+#         for event in pygame.event.get():
+#             if event.type == pygame.QUIT:
+#                 pygame.quit()
+#                 exit()
+
+#             if event.type == pygame.KEYUP and event.key == pygame.K_r:
+#                 game_engine.reset()
+#                 prev_score = game_engine.score
+
+#         if not game_engine.game_is_over:
+#             start_inf_time = time.time()
+#             policy_net_output = DQN.infer_action(policy_net, cur_state)
+#             inf_times.append(time.time() - start_inf_time)
+#             action: Action = policy_net_output.action
+
+#             move_result: MoveResult = game_engine.move(action)
+#             if move_result.suc:
+#                 game_engine.generate_new()
+#             else:
+#                 move_failure += 1
+#                 # action_candidates = [
+#                 #     candidate for candidate in Action if candidate != action
+#                 # ]
+#                 # shuffle(action_candidates)
+#                 # for action in action_candidates:
+#                 #     move_result = game_engine.move(action)
+#                 #     if move_result.suc:
+#                 #         break
+#                 #     move_failure += 1
+#                 # if not move_result.suc:
+#                 #     raise ValueError("Game is not over yet but all actions failed")
+
+#             if game_engine.score == prev_score:
+#                 score_not_increasing_count += 1
+#             else:
+#                 score_not_increasing_count = 0
+#             prev_score = game_engine.score
+
+#             cur_state = make_state_one_hot(tile)
+
+#             if show_board:
+#                 plotter.plot(game_engine.score)
+#             else:
+#                 tile.reset_animation_grids()
+
+#             if game_engine.game_is_over:
+#                 iter += 1
+#                 if show_board:
+#                     plotter.plot_game_over()
+#                 move_failures.append(move_failure)
+#                 move_failure = 0
+#                 max_grids.append(tile.max_grid())
+#                 total_scores.append(game_engine.score)
+#                 if print_results:
+#                     print(f"Move failures: {move_failures}")
+#                     print(f"Total scores: {total_scores}")
+#                     print(f"Max grids: {max_grids}")
+
+#                 if iter % 10 == 0:
+#                     write_json(
+#                         move_failures,
+#                         total_scores,
+#                         max_grids,
+#                         [],  # total_rewards,
+#                         output_json_fn,
+#                     )
+#                 game_engine.reset()
+
+#     write_json(move_failures, total_scores, max_grids, [], output_json_fn)
+#     elapsed_sec = time.time() - start_time
+#     print(
+#         f"Done running {max_iters} times of experiments in {round(elapsed_sec * 1000.0)} millisecond(s)."
+#     )
+#     print(
+#         f"Average inference time: {(sum(inf_times) / len(inf_times)) * 1000.0} millisecond(s)"
+#     )
+#     print(f"See results in {output_json_fn}.")
+
+
+def main():
+    args = parse_args()
+    if args.eval:
+        # eval_dqn(
+        #     args.show_board,
+        #     args.print_results,
+        #     args.output_json_prefix,
+        #     args.max_iters,
+        #     args.trained_net_path,
+        #     args.network_version,
+        # )
+        pass
+    else:
+        train(
+            args.show_board,
+            args.print_results,
+            args.output_json_prefix,
+            args.output_net_prefix,
+            args.max_iters,
+            args.network_version,
+            args.trained_net_path,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/rl_2048/jax_dqn/dqn.py
+++ b/rl_2048/jax_dqn/dqn.py
@@ -1,0 +1,186 @@
+import math
+import os
+from random import SystemRandom
+from typing import List, NamedTuple, Optional, Sequence, Union
+
+import jax.numpy as jnp
+import numpy as np
+from flax import linen as nn
+from flax.training.checkpoints import restore_checkpoint, save_checkpoint
+from jax import Array
+from jax.tree_util import tree_map
+
+from rl_2048.jax_dqn.net import (
+    BNTrainState,
+    create_train_state,
+    eval_forward,
+    train_step,
+)
+from rl_2048.jax_dqn.replay_memory import Action, Batch, ReplayMemory, Transition
+
+
+class TrainingParameters(NamedTuple):
+    memory_capacity: int = 1024
+    gamma: float = 0.99
+    batch_size: int = 64
+    lr: float = 0.001
+    lr_decay_milestones: Union[int, List[int]] = 100
+    lr_gamma: float = 0.1
+    sgd_momentum: float = 0.9
+
+    # for epsilon-greedy algorithm
+    eps_start: float = 0.9
+    eps_end: float = 0.05
+    eps_decay: float = 400
+
+    # update rate of the target network
+    TAU: float = 0.005
+
+    save_network_steps: int = 1000
+    print_loss_steps: int = 100
+
+
+script_file_path = os.path.dirname(os.path.abspath(__file__))
+
+
+class PolicyNetOutput(NamedTuple):
+    expected_value: float
+    action: Action
+
+
+class DQN:
+    def __init__(
+        self,
+        input_dim: int,
+        policy_net: nn.Module,
+        output_net_dir: str,
+        training_params: TrainingParameters,
+        random_key: Array,
+    ):
+        self.random_key: Array = random_key
+
+        self.policy_net: nn.Module = policy_net
+        self.policy_net_train_state: BNTrainState = create_train_state(
+            self.random_key,
+            self.policy_net,
+            input_dim,
+            training_params.lr,
+            training_params.sgd_momentum,
+        )
+        self.target_net_train_state: BNTrainState = create_train_state(
+            self.random_key,
+            self.policy_net,
+            input_dim,
+            training_params.lr,
+            training_params.sgd_momentum,
+        )
+        self.target_net_train_state = self.target_net_train_state.replace(
+            params=self.policy_net_train_state.params,
+            batch_stats=self.policy_net_train_state.batch_stats,
+        )
+
+        self.output_net_dir: str = output_net_dir
+
+        self.training_params = training_params
+        self.memory = ReplayMemory(
+            self.random_key, self.training_params.memory_capacity
+        )
+        self.optimize_steps: int = 0
+        self.losses: List[float] = []
+
+        self._cryptogen: SystemRandom = SystemRandom()
+
+    @staticmethod
+    def infer_action(
+        policy_net_state: BNTrainState,
+        state: Sequence[float],
+    ) -> PolicyNetOutput:
+        raw_values: Array = eval_forward(
+            policy_net_state, jnp.array(np.array(state))[None, :]
+        )[0]
+        best_action: int = jnp.argmax(raw_values).item()
+        best_value: float = raw_values[best_action].item()
+        return PolicyNetOutput(best_value, Action(best_action))
+
+    def get_best_action(self, state: Sequence[float]) -> Action:
+        best_action = self.infer_action(self.policy_net_train_state, state).action
+        return best_action
+
+    def get_action_epsilon_greedy(self, state: Sequence[float]) -> Action:
+        eps_threshold = self.training_params.eps_end + (
+            self.training_params.eps_start - self.training_params.eps_end
+        ) * math.exp(-1.0 * self.optimize_steps / self.training_params.eps_decay)
+
+        if self._cryptogen.random() > eps_threshold:
+            return self.get_best_action(state)
+
+        return Action(self._cryptogen.randrange(len(Action)))
+
+    def push_transition(self, transition: Transition):
+        self.memory.push(transition)
+
+    def optimize_model(self) -> float:
+        if len(self.memory) < self.training_params.batch_size:
+            return 0.0
+
+        self.optimize_steps += 1
+
+        batch: Batch = self.memory.sample(
+            min(self.training_params.batch_size, len(self.memory))
+        )
+        next_value_predictions = eval_forward(
+            self.target_net_train_state, batch.next_states
+        )
+        next_state_values = next_value_predictions.max(axis=1, keepdims=True)
+        expected_state_action_values: Array = batch.rewards + (
+            self.training_params.gamma * next_state_values
+        ) * (1.0 - batch.games_over)
+        self.policy_net_train_state, loss = train_step(
+            self.policy_net_train_state, batch, expected_state_action_values
+        )
+        self.losses.append(loss.item())
+
+        # Soft update of the target network's weights
+        # θ′ ← τ θ + (1 −τ )θ′
+        tau: float = self.training_params.TAU
+        target_net_params = tree_map(
+            lambda p, tp: p * tau + tp * (1 - tau),
+            self.policy_net_train_state.params,
+            self.target_net_train_state.params,
+        )
+        target_net_batch_stats = tree_map(
+            lambda p, tp: p * tau + tp * (1 - tau),
+            self.policy_net_train_state.batch_stats,
+            self.target_net_train_state.batch_stats,
+        )
+        self.target_net_train_state = self.target_net_train_state.replace(
+            params=target_net_params, batch_stats=target_net_batch_stats
+        )
+
+        if self.optimize_steps % self.training_params.print_loss_steps == 0:
+            print(
+                f"Done optimizing {self.optimize_steps} steps. "
+                f"Average loss: {np.mean(self.losses).item()}"
+            )
+            self.losses = []
+        if self.optimize_steps % self.training_params.save_network_steps == 0:
+            self.save_model(f"{self.output_net_dir}/step_{self.optimize_steps:04d}")
+
+        return loss.item()
+
+    def save_model(self, root_dir: Optional[str] = None) -> str:
+        ckpt_dir: str = (
+            os.path.abspath(root_dir) if root_dir is not None else self.output_net_dir
+        )
+        saved_path: str = save_checkpoint(
+            ckpt_dir=ckpt_dir,
+            target=self.policy_net_train_state,
+            step=self.optimize_steps,
+        )
+
+        return saved_path
+
+    def load_model(self, model_path: str):
+        self.policy_net_train_state = restore_checkpoint(
+            ckpt_dir=os.path.dirname(model_path), target=self.policy_net_train_state
+        )

--- a/rl_2048/jax_dqn/net.py
+++ b/rl_2048/jax_dqn/net.py
@@ -1,0 +1,109 @@
+from typing import Any, Callable, Mapping, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+import optax
+from flax import linen as nn
+from flax.core import FrozenDict
+from flax.training.train_state import TrainState
+from jax import Array
+from typing_extensions import TypeAlias
+
+from rl_2048.jax_dqn.replay_memory import Batch
+
+Params: TypeAlias = FrozenDict[str, Any]
+Variables: TypeAlias = Union[FrozenDict[str, Mapping[str, Any]], dict[str, Any]]
+GradFn: TypeAlias = Callable[
+    [Params],
+    Tuple[Array, Array],
+]
+
+
+class BNTrainState(TrainState):
+    """TrainState that is used for modules with BatchNorm layers."""
+
+    batch_stats: Any
+
+
+# All Flax Modules are Python 3.7 dataclasses.
+# Since dataclasses take over __init__, you should instead override setup(),
+# which is automatically called to initialize the module.
+class Net(nn.Module):
+    hidden_dims: Tuple[int, ...]
+    output_dim: int
+    activation_fn: Callable
+
+    @nn.compact
+    def __call__(self, x: Array, train: bool = False) -> Array:
+        for hidden_dim in self.hidden_dims:
+            x = nn.Dense(features=hidden_dim, use_bias=False)(x)
+            # https://flax.readthedocs.io/en/latest/guides/training_techniques/batch_norm.html
+            x = nn.BatchNorm(use_running_average=not train)(x)
+            x = self.activation_fn(x)
+
+        return nn.Dense(features=self.output_dim)(x)
+
+
+def create_train_state(
+    rng: Array,
+    net: nn.Module,
+    input_dim: int,
+    learning_rate: float,
+    momentum: float = 0.9,
+) -> BNTrainState:
+    variables: Variables = net.init(rng, jnp.ones([1, input_dim]))
+    tx: optax.GradientTransformation = optax.sgd(learning_rate, momentum)
+    return BNTrainState.create(
+        apply_fn=net.apply,
+        params=variables["params"],
+        batch_stats=variables["batch_stats"],
+        tx=tx,
+    )
+
+
+@jax.jit
+def train_step(
+    train_state: BNTrainState, input_batch: Batch, targets: Array
+) -> Tuple[BNTrainState, Any]:
+    """Computes gradients and loss for a single batch."""
+
+    def loss_fn(params) -> Tuple[Array, Tuple[Array, Array]]:
+        raw_pred, updates = train_state.apply_fn(
+            {"params": params, "batch_stats": train_state.batch_stats},
+            x=input_batch.states,
+            train=True,
+            mutable=["batch_stats"],
+        )
+
+        predictions: Array = jnp.take_along_axis(raw_pred, input_batch.actions, axis=1)
+        loss = jnp.mean(optax.squared_error(predictions, targets))
+        return loss, (predictions, updates)
+
+    grad_fn: GradFn = jax.value_and_grad(loss_fn, has_aux=True)
+    (loss, (_predictions, updates)), grads = grad_fn(train_state.params)
+
+    train_state = train_state.apply_gradients(grads=grads)
+    train_state = train_state.replace(batch_stats=updates["batch_stats"])
+
+    return train_state, loss
+
+
+@jax.jit
+def eval_forward(train_state: BNTrainState, inputs: Array) -> Array:
+    predictions = train_state.apply_fn(
+        {"params": train_state.params, "batch_stats": train_state.batch_stats},
+        x=inputs,
+        train=False,
+    )
+    return predictions
+
+
+@jax.jit
+def train_forward(train_state: BNTrainState, inputs: Array) -> Tuple[Array, Variables]:
+    predictions, updates = train_state.apply_fn(
+        {"params": train_state.params, "batch_stats": train_state.batch_stats},
+        x=inputs,
+        train=True,
+        mutable=["batch_stats"],
+    )
+    return predictions, updates

--- a/rl_2048/jax_dqn/replay_memory.py
+++ b/rl_2048/jax_dqn/replay_memory.py
@@ -1,0 +1,115 @@
+import random
+from enum import Enum
+from typing import List, NamedTuple, Sequence
+
+import jax.numpy as jnp
+import jax.random as jrandom
+import numpy as np
+from jax import Array
+
+
+class Action(Enum):
+    UP = 0
+    DOWN = 1
+    LEFT = 2
+    RIGHT = 3
+
+
+# N: number of grids in the board
+class Transition(NamedTuple):
+    state: Sequence[
+        float
+    ]  # size: N (if represented by float) or N*16 (if represented by one-hot)
+    action: Action
+    next_state: Sequence[float]  # not really used in training
+    reward: float
+    game_over: bool
+
+
+class Batch(NamedTuple):
+    states: Array
+    actions: Array
+    next_states: Array
+    rewards: Array
+    games_over: Array
+
+
+class ReplayMemory:
+    def __init__(self, rng: Array, capacity: int = 1024):
+        self.rng = rng
+        self.capacity: int = capacity
+
+        self.states: List[Sequence[float]] = [[] for _ in range(capacity)]
+        self.actions: List[int] = [0 for _ in range(capacity)]
+        self.next_states: List[Sequence[float]] = [[] for _ in range(capacity)]
+        self.rewards: List[float] = [0.0 for _ in range(capacity)]
+        self.games_over: List[bool] = [False for _ in range(capacity)]
+        self.next_index: int = 0
+        self.is_full: bool = False
+
+    def reset(self):
+        self.states = [[]] * self.capacity
+        self.actions = [0] * self.capacity
+        self.next_states = [[]] * self.capacity
+        self.rewards = [0.0] * self.capacity
+        self.games_over = [False] * self.capacity
+        self.next_index = 0
+        self.is_full = False
+
+    def push(self, transition: Transition):
+        self.states[self.next_index] = transition.state
+        self.actions[self.next_index] = transition.action.value
+        self.next_states[self.next_index] = transition.next_state
+        self.rewards[self.next_index] = transition.reward
+        self.games_over[self.next_index] = transition.game_over
+        self.next_index += 1
+        if self.next_index >= self.capacity:
+            self.is_full = True
+            self.next_index = 0
+
+    def sample(self, batch_size: int) -> Batch:
+        random_indices = random.sample(list(range(len(self))), batch_size)
+        batch = Batch(
+            jnp.array(np.array([self.states[i] for i in random_indices])),
+            jnp.array(
+                np.array([self.actions[i] for i in random_indices]).reshape((-1, 1))
+            ),
+            jnp.array(
+                np.array([self.next_states[i] for i in random_indices]),
+            ),
+            jnp.array(
+                np.array([self.rewards[i] for i in random_indices]).reshape((-1, 1))
+            ),
+            jnp.array(
+                np.array([float(self.games_over[i]) for i in random_indices]).reshape(
+                    (-1, 1)
+                )
+            ),
+        )
+
+        return batch
+
+    def __len__(self):
+        return self.capacity if self.is_full else self.next_index
+
+
+if __name__ == "__main__":
+    rng = jrandom.key(0)
+    memory = ReplayMemory(rng)
+    t1 = Transition(
+        state=[1.0, 0.5],
+        action=Action.UP,
+        next_state=[2.0, 0.0],
+        reward=10.0,
+        game_over=False,
+    )
+    t2 = Transition(
+        state=[2.0, 0.0],
+        action=Action.LEFT,
+        next_state=[-0.5, 1.0],
+        reward=-1.0,
+        game_over=False,
+    )
+    memory.push(t1)
+    memory.push(t2)
+    print(memory.sample(2))

--- a/rl_2048/jax_dqn/utils.py
+++ b/rl_2048/jax_dqn/utils.py
@@ -1,0 +1,7 @@
+import math
+from typing import Sequence
+
+
+def flat_one_hot(values: Sequence[int], k: int) -> Sequence[float]:
+    locations = (0 if v == 0 else int(math.log2(v)) for v in values)
+    return [1.0 if i == loc else 0.0 for loc in locations for i in range(k)]

--- a/rl_2048/tile.py
+++ b/rl_2048/tile.py
@@ -24,6 +24,18 @@ class Tile:
 
         self.random_start()
 
+    def flattened(self) -> List[int]:
+        return [g for row in self.grids for g in row]
+
+    def __repr__(self) -> str:
+        s: str = "-" * (8 * self.width + 1) + "\n"
+        for row in self.grids:
+            s += "|"
+            for g in row:
+                s += f" {g:05d} |"
+            s += "\n" + "-" * (8 * self.width + 1) + "\n"
+        return s
+
     def set_grids(self, grids: List[List[int]]):
         if len(grids) != self.height:
             raise ValueError(

--- a/tests/jax_dqn/test_dqn.py
+++ b/tests/jax_dqn/test_dqn.py
@@ -1,0 +1,54 @@
+import tempfile
+
+from flax import linen as nn
+from jax import Array
+from jax import random as jrandom
+
+from rl_2048.jax_dqn.dqn import DQN, TrainingParameters
+from rl_2048.jax_dqn.net import Net
+from rl_2048.jax_dqn.replay_memory import Action, Transition
+
+
+def test_dqn():
+    input_dim = 2
+    hidden_dims = (3,)
+    output_dim = 4
+    training_params = TrainingParameters(
+        memory_capacity=2,
+        gamma=0.99,
+        batch_size=2,
+        lr=0.001,
+        sgd_momentum=0.9,
+        eps_start=0.0,
+        eps_end=0.0,
+    )
+    rng: Array = jrandom.key(0)
+    policy_net: nn.Module = Net(hidden_dims, output_dim, nn.relu)
+
+    t1 = Transition(
+        state=[1.0, 0.5],
+        action=Action.UP,
+        next_state=[2.0, 0.0],
+        reward=10.0,
+        game_over=False,
+    )
+    t2 = Transition(
+        state=[2.0, 0.0],
+        action=Action.LEFT,
+        next_state=[-0.5, 1.0],
+        reward=-1.0,
+        game_over=False,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dqn = DQN(input_dim, policy_net, tmp_dir, training_params, rng)
+
+        dqn.push_transition(t1)
+        dqn.push_transition(t2)
+        loss = dqn.optimize_model()
+        assert loss != 0.0
+
+        print(dqn.get_action_epsilon_greedy(t2.state))
+
+        model_path = dqn.save_model()
+        dqn.load_model(model_path)

--- a/tests/jax_dqn/test_replay_memory.py
+++ b/tests/jax_dqn/test_replay_memory.py
@@ -1,0 +1,70 @@
+import jax.random as jrandom
+from jax import Array
+
+from rl_2048.jax_dqn.replay_memory import Action, Batch, ReplayMemory, Transition
+
+all_memory_fields = {"states", "actions", "next_states", "rewards", "games_over"}
+
+
+def check_size(memory: ReplayMemory, expected_size: int):
+    assert memory.is_full == (expected_size == memory.capacity)
+    assert len(memory) == expected_size
+
+
+def test_replay_memory():
+    rng: Array = jrandom.key(0)
+    capacity: int = 4
+    state_size: int = 2
+    memory = ReplayMemory(rng, capacity)
+    t1 = Transition(
+        state=[1.0] + [0.0 for _ in range(state_size - 1)],
+        action=Action.UP,
+        next_state=[2.0] + [0.0 for _ in range(state_size - 1)],
+        reward=2.0,
+        game_over=False,
+    )
+    t2 = Transition(
+        state=[2.0] + [0.0 for _ in range(state_size - 1)],
+        action=Action.DOWN,
+        next_state=[3.0] + [0.0 for _ in range(state_size - 1)],
+        reward=3.0,
+        game_over=False,
+    )
+    t3 = Transition(
+        state=[3.0] + [0.0 for _ in range(state_size - 1)],
+        action=Action.LEFT,
+        next_state=[4.0] + [0.0 for _ in range(state_size - 1)],
+        reward=4.0,
+        game_over=False,
+    )
+    t4 = Transition(
+        state=[4.0] + [0.0 for _ in range(state_size - 1)],
+        action=Action.RIGHT,
+        next_state=[0.0] + [0.0 for _ in range(state_size - 1)],
+        reward=-1.0,
+        game_over=True,
+    )
+
+    assert memory.capacity == capacity
+    check_size(memory, 0)
+
+    assert memory.next_index == 0
+    memory.push(t1)
+    check_size(memory, 1)
+    assert memory.next_index == 1
+    memory.push(t2)
+    check_size(memory, 2)
+    assert memory.next_index == 2
+    memory.push(t3)
+    check_size(memory, 3)
+    assert memory.next_index == 3
+    memory.push(t4)
+    check_size(memory, 4)
+    assert memory.next_index == 0
+
+    sample_size: int = 3
+    batch: Batch = memory.sample(sample_size)
+    expected_shapes = {
+        f: (sample_size, (state_size if "states" in f else 1)) for f in batch._fields
+    }
+    assert all(getattr(batch, f).shape == expected_shapes[f] for f in batch._fields)

--- a/tests/jax_dqn/test_utils.py
+++ b/tests/jax_dqn/test_utils.py
@@ -1,0 +1,20 @@
+from typing import Sequence
+
+from rl_2048.jax_dqn.utils import flat_one_hot
+
+
+def test_flat_one_hot():
+    input: Sequence[int] = [0, 2, 4, 8, 16]
+    features: Sequence[float] = flat_one_hot(input, 5)
+    # fmt: off
+    expected: Sequence[float] = [
+        1., 0., 0., 0., 0.,
+        0., 1., 0., 0., 0.,
+        0., 0., 1., 0., 0.,
+        0., 0., 0., 1., 0.,
+        0., 0., 0., 0., 1.,
+    ]
+    # fmt: on
+    assert len(features) == len(expected) and all(
+        a == b for a, b in zip(features, expected)
+    )

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -17,3 +17,25 @@ def test_tile():
         tile.reset_animation_grids()
         assert len(tile.animation_grids) == 0
         tile.random_start()
+
+
+def test_tile_flattened():
+    tile = Tile(width=5, height=3)
+    # fmt: off
+    tile.grids = [
+        [0, 0, 2, 4, 0],
+        [4, 8, 0, 2, 0],
+        [0, 0, 2, 0, 2]
+    ]
+    # fmt: on
+    flattened: List[int] = tile.flattened()
+    # fmt: off
+    expected: List[int] = [
+        0, 0, 2, 4, 0,
+        4, 8, 0, 2, 0,
+        0, 0, 2, 0, 2
+    ]
+    # fmt: on
+    assert len(flattened) == len(expected) and all(
+        a == b for a, b in zip(flattened, expected)
+    )


### PR DESCRIPTION
# Why to use JAX instead of PyTorch?

1. **Relatively lightweight**: I have noticed that PyTorch is now too powerful for the question in hand. All I need to use is to build simple network (few linear layers, typical activation layers, etc.), optimize weights with simple loss functions (Huber loss, L2 loss, etc.). For example, the [latest build of PyTorch v2.3.0](https://github.com/pytorch/pytorch/releases/tag/v2.3.0) has the file size (265 MB), but [JAX v0.4.28](https://github.com/google/jax/releases/tag/jax-v0.4.28) is only 14.1 MB. I also used [Flax v0.8.3](https://github.com/google/flax/releases/tag/v0.8.3) to build networks and use its optimizer, which is also very light weight, only 2.9 MB.
2. **Just to learn and practice using new tools**: I have learned JAX last year when I did my capstone project at ETHZ, but eventually I didn't need to write much code with JAX. Still, being curious to see if I can replace PyTorch with it, so I decided to use this project as a good starting point. Btw, kudos ⭐ to my supervisor Simon and his [JAX-based simulation-based inference library](https://github.com/dirmeier/sbijax). I definitely took a lot of inspirations from this repository.

# What is my experience using JAX?

## Code

In overall, I might be just too familiar with PyTorch, so I have noticed quite many differences in how the code is written. For example, for a simple network:

```
# PyTorch
import torch
from torch import Tensor, nn, optim


class Network(nn.Module):
    def __init__(self):
        nn.Module.__init__(self)
        self.linear1: nn.Module = nn.Linear(3, 5)
        self.relu = nn.ReLU()
        self.linear2: nn.Module = nn.Linear(5, 2)

    def forward(self, x):
        x = self.linear1(x)
        x = self.relu(x)
        return self.linear2(x)


network = Network()
optimizer = optim.Adam(network.parameters())

input_tensor: Tensor = torch.tensor(
    [[-1, -2, -3], [1, 2, 3]], dtype=torch.float32
)  # Batch size 2, input size 3
output_tensor: Tensor = network(input_tensor)
target_tensor: Tensor = torch.tensor([[1, 2], [3, 4]], dtype=torch.float32)

loss_fn = nn.HuberLoss()
loss = loss_fn(output_tensor, target_tensor)

optimizer.zero_grad()
loss.backward()
optimizer.step()
```

```
# JAX / Flax
from typing import Any, Tuple
import jax
import jax.numpy as jnp
from flax import linen as nn
from flax.training.train_state import TrainState
import optax


class Network(nn.Module):
    @nn.compact
    def __call__(self, x: jax.Array) -> jax.Array:
        x = nn.Dense(features=5)(x)
        x = nn.relu(x)
        return nn.Dense(features=2)(x)


def create_train_state(rng: jax.Array, net: nn.Module) -> TrainState:
    variables = net.init(rng, jnp.ones((1, 3), dtype=jnp.float32))  # input size 3
    tx: optax.GradientTransformation = optax.adam(0.001)
    return TrainState.create(
        apply_fn=net.apply,
        params=variables["params"],
        tx=tx,
    )


@jax.jit
def train_step(
    train_state: TrainState, inputs: jax.Array, targets: jax.Array
) -> Tuple[TrainState, Any]:
    def loss_fn(params) -> jax.Array:
        pred = train_state.apply_fn(
            {"params": params},
            inputs,
        )
        loss = jnp.mean(optax.huber_loss(pred, targets))

        return loss

    grad_fn = jax.value_and_grad(loss_fn, has_aux=False)
    loss, grads = grad_fn(train_state.params)

    train_state = train_state.apply_gradients(grads=grads)

    return train_state, loss


rng: jax.Array = jax.random.key(0)
network = Network()
train_state = create_train_state(rng, network)

inputs: jax.Array = jnp.array(
    [[-1.0, -2.0, -3.0], [1.0, 2.0, 3.0]], dtype=jnp.float32
)  # Batch size 2, input size 3
targets: jax.Array = jnp.array([[1.0, 2.0], [3.0, 4.0]], dtype=jnp.float32)
train_state, loss = train_step(train_state, inputs, targets)
print(loss)
```

We can see that the network construction is very similar, but how to train the model is much more complex, for example, parameters must be created separately and passed around; there is "train state" which includes apply function from the network, state during the training, and even the network weights. But then we still need to pass weights around when we compute the loss or make a forward pass. Even worse, after getting the gradients, we must apply it to the training state and manually update the state in the program.

In overall, that is fine if it simply works. What annoyed me the most is the less useful debug message and lack of actual line information. Every time it took me more than few hours to figure out a very small bug, for example, writing `nn.relu()(x)` with the redundant parenthesis, or passing only `params` to `train_state.apply_fn` without the dictionary.

Maybe it's also because I didn't read the document from the beginning very well, so I didn't understand the concept well enough to figure out the errors.

### Where the weights are stored

In PyTorch, weights gradients are stored in `nn.Module` itself, so we only need to keep the network in one place. But in JAX / Flax, training states, weights, gradients, losses, etc. are all returned and need to be managed by ourselves, so the readability is not that great.

## Performance on CPU

When I finished the first working version, I realized that the total training time is almost twice compared to the PyTorch implementation, which was very disappointing. I don't really want to sacrifice the performance for package size. Then after some effort, I found that making jnp.array from lists of lists is very slow. From [this discussion](https://github.com/google/jax/issues/10662), I then found out I could simply make it more than 10x faster by converting to `np.array` first, then `jnp.arary`. To be honest, I don't like it.

## Documentation

I found out that the documentation is not well organized. And I remembered some of the tutorials were not up-to-date. Many functions do not provide simple examples in their docstring.

But sometimes they appear to be very helpful, for example, [BatchNorm](https://flax.readthedocs.io/en/latest/guides/training_techniques/batch_norm.html) layers require manually changing "few" lines of code in order to make it work, as it contains `batch_stats` that we need to pass around and update. Following the document made the work slightly easier. Only a bit.

In general, I still haven't found any benefits of using JAX over PyTorch, maybe I will figure it out later if I use it more. But so far, it still has lots of rooms for improvement, and before it gets better, I may not try again in the future for simple projects.