### PR TITLE
Add residual networks

### DIFF
--- a/rl_2048/DQN/net.py
+++ b/rl_2048/DQN/net.py
@@ -110,8 +110,6 @@ class Net(nn.Module):
                 )
 
             layers.append(activation_layer)
-            # if i < len(hidden_layer_sizes) - 1:
-            #     layers.append(nn.Dropout())
 
             in_features = out_features
         layers.append(nn.Linear(in_features, output_feature_size, bias))

--- a/tests/jax_dqn/test_dqn.py
+++ b/tests/jax_dqn/test_dqn.py
@@ -1,17 +1,15 @@
 import tempfile
 
-from flax import linen as nn
 from jax import Array
 from jax import random as jrandom
 
 from rl_2048.jax_dqn.dqn import DQN, TrainingParameters
-from rl_2048.jax_dqn.net import Net
+from rl_2048.jax_dqn.net import PREDEFINED_NETWORKS, Net, load_predefined_net
 from rl_2048.jax_dqn.replay_memory import Action, Transition
 
 
 def test_dqn():
-    input_dim = 2
-    hidden_dims = (3,)
+    input_dim = 100
     output_dim = 4
     training_params = TrainingParameters(
         memory_capacity=2,
@@ -23,32 +21,34 @@ def test_dqn():
         eps_end=0.0,
     )
     rng: Array = jrandom.key(0)
-    policy_net: nn.Module = Net(hidden_dims, output_dim, nn.relu)
-
     t1 = Transition(
-        state=[1.0, 0.5],
+        state=jrandom.normal(rng, shape=(input_dim,)).tolist(),
         action=Action.UP,
-        next_state=[2.0, 0.0],
+        next_state=jrandom.normal(rng, shape=(input_dim,)).tolist(),
         reward=10.0,
         game_over=False,
     )
     t2 = Transition(
-        state=[2.0, 0.0],
+        state=jrandom.normal(rng, shape=(input_dim,)).tolist(),
         action=Action.LEFT,
-        next_state=[-0.5, 1.0],
+        next_state=jrandom.normal(rng, shape=(input_dim,)).tolist(),
         reward=-1.0,
         game_over=False,
     )
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        dqn = DQN(input_dim, policy_net, tmp_dir, training_params, rng)
+    for network_version in PREDEFINED_NETWORKS:
+        policy_net: Net = load_predefined_net(network_version, output_dim)
+        policy_net.check_correctness()
 
-        dqn.push_transition(t1)
-        dqn.push_transition(t2)
-        loss = dqn.optimize_model()
-        assert loss != 0.0
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dqn = DQN(input_dim, policy_net, tmp_dir, training_params, rng)
 
-        print(dqn.get_action_epsilon_greedy(t2.state))
+            dqn.push_transition(t1)
+            dqn.push_transition(t2)
+            loss = dqn.optimize_model()
+            assert loss != 0.0
 
-        model_path = dqn.save_model()
-        dqn.load_model(model_path)
+            print(dqn.get_action_epsilon_greedy(t2.state))
+
+            model_path = dqn.save_model()
+            dqn.load_model(model_path)


### PR DESCRIPTION
Add residual blocks to jax_dqn networks.

Trained `layers_512_512_residual_0_128` network with 10,000 game executions successfully and results look good:
```
# Training hyper-parameters:
    training_params = TrainingParameters(
        memory_capacity=20000,
        gamma=0.99,
        batch_size=128,
        lr=1e-3,
        lr_decay_milestones=[1500, 3000, 5000, 7000],
        lr_gamma=0.1,
        eps_start=0.9,
        eps_end=0.05,
        eps_decay=1500,
        TAU=0.005,
        save_network_steps=2000,
        print_loss_steps=500,
    )

Done optimizing 11500 steps. Average loss: 1.2819547723531723
Done running 10000 times of experiments in 462588 millisecond(s).
```
In average 46.3 msec / step.

![image](https://github.com/FangLinHe/RL2048/assets/8507520/907486a9-6f04-4d79-b3ed-600fc3392cc5)
![image](https://github.com/FangLinHe/RL2048/assets/8507520/d52581ac-dd7a-447d-8eb7-67a582b46bab)
![image](https://github.com/FangLinHe/RL2048/assets/8507520/ee79eca6-8795-47b4-8517-68294b80187e)
![image](https://github.com/FangLinHe/RL2048/assets/8507520/2f3a1243-b849-4738-a787-82a09d956114)
![image](https://github.com/FangLinHe/RL2048/assets/8507520/b111f498-6d1a-4103-a433-22aba47c83cf)
![image](https://github.com/FangLinHe/RL2048/assets/8507520/e56a559b-1817-4507-ace4-db68cfa25f15)
![image](https://github.com/FangLinHe/RL2048/assets/8507520/6e13d0e8-e6a0-4207-8edb-fac2a20e92bc)
![image](https://github.com/FangLinHe/RL2048/assets/8507520/b89e7fdd-5eed-42e3-a006-fe0520efd9bf)

 Now training with 100k game executions.