### PR TITLE
Game statistics with game execution iters

### DIFF
--- a/rl_2048/bin/playRL2048_jax_dqn.py
+++ b/rl_2048/bin/playRL2048_jax_dqn.py
@@ -134,12 +134,12 @@ def train(
         batch_size=128,
         optimizer="adamw",
         lr=1e-3,
-        lr_decay_milestones=[],
+        lr_decay_milestones=[50000],
         lr_gamma=0.1,
         loss_fn="huber_loss",
         eps_start=0.9,
         eps_end=0.05,
-        eps_decay=15000,
+        eps_decay=10000,
         TAU=0.005,
         save_network_steps=2000,
         print_loss_steps=500,
@@ -240,21 +240,21 @@ def train(
                 total_scores.append(game_engine.score)
 
                 dqn.summary_writer.add_scalar(
-                    "game_statistics/game_iter", iter, dqn.optimize_steps
+                    "game_statistics/opt_steps", dqn.optimize_steps, iter
                 )
                 dqn.summary_writer.add_scalar(
-                    "game_statistics/move_failures", move_failure, dqn.optimize_steps
+                    "game_statistics/move_failures", move_failure, iter
                 )
                 dqn.summary_writer.add_scalar(
                     "game_statistics/total_scores",
                     game_engine.score,
-                    dqn.optimize_steps,
+                    iter,
                 )
                 dqn.summary_writer.add_scalar(
-                    "game_statistics/max_grids", max_grid, dqn.optimize_steps
+                    "game_statistics/max_grids", max_grid, iter
                 )
                 dqn.summary_writer.add_scalar(
-                    "game_statistics/total_rewards", total_reward, dqn.optimize_steps
+                    "game_statistics/total_rewards", total_reward, iter
                 )
 
                 total_rewards.append(total_reward)


### PR DESCRIPTION
* Previously, I logged game statistics with current optimizer step, but it increments 50 at a time, so I lost the precision. Change it to game execution iter to keep the precision.
* Good experiment settings: LR decay only once; eps_decay 10k
  - Reduce LR by 1/10 after training 50k iterations makes the model more stable: much less move failures and higher total score.
<img width="1392" alt="image" src="https://github.com/FangLinHe/RL2048/assets/8507520/c7816736-06b9-45b8-8bb6-9d05d88edceb">
<img width="1346" alt="image" src="https://github.com/FangLinHe/RL2048/assets/8507520/b96a6f62-09c2-4886-954b-e594f3a41fab">
  