### PR TITLE
Evaluate DQN trained network

### DIFF
--- a/rl_2048/bin/playRL2048_dqn.py
+++ b/rl_2048/bin/playRL2048_dqn.py
@@ -319,7 +319,7 @@ def eval_dqn(
     network_version: str,
 ):
     tile: Tile = Tile(width=4, height=4)
-    plot_properties: PlotProperties = PlotProperties(fps=60, delay_after_plot=50)
+    plot_properties: PlotProperties = PlotProperties(fps=60, delay_after_plot=0)
     plotter: TilePlotter = TilePlotter(tile, plot_properties)
     game_engine: GameEngine = GameEngine(tile)
 


### PR DESCRIPTION
Ran the command:
```
python rl_2048/bin/playRL2048_jax_dqn.py \
  --max_iters 1000 --eval \
  --output_json_prefix Experiments/eval_jaxdqn_layers_512_512_residual_0_128_100kiters \
  --network_version layers_512_512_residual_0_128 \
  --trained_net_path TrainedNetworks/jax_dqn/keep/jaxdqn_layers_512_512_residual_0_128_100kiters_20240524_123652/checkpoint_108000
```

Gave the output:
```
Done running 1000 times of experiments in 54134 millisecond(s).
Average inference time: 0.25563764545740614 millisecond(s)
See results in Experiments/eval_jaxdqn_layers_512_512_residual_0_128_100kiters_20240609_184031.json.
```