### PR TITLE
Move Action, PolicyNetOutput, TrainingParameters to common

### DIFF
--- a/rl_2048/bin/playRL2048_dqn.py
+++ b/rl_2048/bin/playRL2048_dqn.py
@@ -15,9 +15,10 @@ import pygame
 import torch
 from torch import nn
 
+from rl_2048.dqn.common import Action
 from rl_2048.dqn.torch.dqn import DQN, TrainingParameters
 from rl_2048.dqn.torch.net import Net
-from rl_2048.dqn.torch.replay_memory import Action, Transition
+from rl_2048.dqn.torch.replay_memory import Transition
 from rl_2048.game_engine import GameEngine, MoveResult
 from rl_2048.tile import Tile
 from rl_2048.tile_plotter import PlotProperties, TilePlotter

--- a/rl_2048/bin/playRL2048_jax_dqn.py
+++ b/rl_2048/bin/playRL2048_jax_dqn.py
@@ -17,12 +17,13 @@ from flax.training.checkpoints import PyTree, restore_checkpoint
 from jax import Array
 from jax import random as jrandom
 
+from rl_2048.dqn.common import Action
 from rl_2048.dqn.jax.dqn import (
     DQN,
     TrainingParameters,
 )
 from rl_2048.dqn.jax.net import PREDEFINED_NETWORKS, load_predefined_net
-from rl_2048.dqn.jax.replay_memory import Action, Transition
+from rl_2048.dqn.jax.replay_memory import Transition
 from rl_2048.dqn.jax.utils import flat_one_hot
 from rl_2048.game_engine import GameEngine, MoveResult
 from rl_2048.tile import Tile

--- a/rl_2048/dqn/common.py
+++ b/rl_2048/dqn/common.py
@@ -1,0 +1,39 @@
+from enum import Enum
+from typing import NamedTuple, Union
+
+
+class Action(Enum):
+    UP = 0
+    DOWN = 1
+    LEFT = 2
+    RIGHT = 3
+
+
+class TrainingParameters(NamedTuple):
+    memory_capacity: int = 1024
+    gamma: float = 0.99
+    batch_size: int = 64
+    optimizer: str = "adamw"
+    lr: float = 0.001
+    lr_decay_milestones: Union[int, list[int]] = 100
+    lr_gamma: Union[float, list[float]] = 0.1
+    loss_fn: str = "huber_loss"
+
+    # for epsilon-greedy algorithm
+    eps_start: float = 0.9
+    eps_end: float = 0.05
+    eps_decay: float = 400
+
+    # update rate of the target network
+    TAU: float = 0.005
+
+    save_network_steps: int = 1000
+    print_loss_steps: int = 100
+    tb_write_steps: int = 50
+
+    pretrained_net_path: str = ""
+
+
+class PolicyNetOutput(NamedTuple):
+    expected_value: float
+    action: Action

--- a/rl_2048/dqn/jax/dqn.py
+++ b/rl_2048/dqn/jax/dqn.py
@@ -2,7 +2,7 @@ import math
 import os
 from collections.abc import Sequence
 from random import SystemRandom
-from typing import Any, Callable, NamedTuple, Optional, Union
+from typing import Any, Callable, Optional
 
 import jax.numpy as jnp
 import numpy as np
@@ -13,46 +13,14 @@ from jax import Array
 from jax.tree_util import tree_map
 from tensorboardX import SummaryWriter
 
+from rl_2048.dqn.common import Action, PolicyNetOutput, TrainingParameters
 from rl_2048.dqn.jax.net import (
     BNTrainState,
     create_train_state,
     eval_forward,
     train_step,
 )
-from rl_2048.dqn.jax.replay_memory import Action, Batch, ReplayMemory, Transition
-
-
-class TrainingParameters(NamedTuple):
-    memory_capacity: int = 1024
-    gamma: float = 0.99
-    batch_size: int = 64
-    optimizer: str = "adamw"
-    lr: float = 0.001
-    lr_decay_milestones: Union[int, list[int]] = 100
-    lr_gamma: Union[float, list[float]] = 0.1
-    loss_fn: str = "huber_loss"
-
-    # for epsilon-greedy algorithm
-    eps_start: float = 0.9
-    eps_end: float = 0.05
-    eps_decay: float = 400
-
-    # update rate of the target network
-    TAU: float = 0.005
-
-    save_network_steps: int = 1000
-    print_loss_steps: int = 100
-    tb_write_steps: int = 50
-
-    pretrained_net_path: str = ""
-
-
-script_file_path = os.path.dirname(os.path.abspath(__file__))
-
-
-class PolicyNetOutput(NamedTuple):
-    expected_value: float
-    action: Action
+from rl_2048.dqn.jax.replay_memory import Batch, ReplayMemory, Transition
 
 
 def create_learning_rate_fn(training_params: TrainingParameters) -> optax.Schedule:

--- a/rl_2048/dqn/jax/replay_memory.py
+++ b/rl_2048/dqn/jax/replay_memory.py
@@ -1,6 +1,5 @@
 import random
 from collections.abc import Sequence
-from enum import Enum
 from typing import NamedTuple
 
 import jax.numpy as jnp
@@ -8,12 +7,7 @@ import jax.random as jrandom
 import numpy as np
 from jax import Array
 
-
-class Action(Enum):
-    UP = 0
-    DOWN = 1
-    LEFT = 2
-    RIGHT = 3
+from rl_2048.dqn.common import Action
 
 
 # N: number of grids in the board

--- a/rl_2048/dqn/torch/dqn.py
+++ b/rl_2048/dqn/torch/dqn.py
@@ -1,43 +1,14 @@
 import math
-import os
 import tempfile
 from collections.abc import Sequence
 from random import SystemRandom
-from typing import NamedTuple, Union
 
 import torch
 from torch import Tensor, nn, optim
 
+from rl_2048.dqn.common import Action, PolicyNetOutput, TrainingParameters
 from rl_2048.dqn.torch.net import Net
-from rl_2048.dqn.torch.replay_memory import Action, Batch, ReplayMemory, Transition
-
-
-class TrainingParameters(NamedTuple):
-    memory_capacity: int = 1024
-    gamma: float = 0.99
-    batch_size: int = 64
-    lr: float = 0.001
-    lr_decay_milestones: Union[int, list[int]] = 100
-    lr_gamma: float = 0.1
-
-    # for epsilon-greedy algorithm
-    eps_start: float = 0.9
-    eps_end: float = 0.05
-    eps_decay: float = 400
-
-    # update rate of the target network
-    TAU: float = 0.005
-
-    save_network_steps: int = 1000
-    print_loss_steps: int = 100
-
-
-script_file_path = os.path.dirname(os.path.abspath(__file__))
-
-
-class PolicyNetOutput(NamedTuple):
-    expected_value: float
-    action: Action
+from rl_2048.dqn.torch.replay_memory import Batch, ReplayMemory, Transition
 
 
 class DQN:

--- a/rl_2048/dqn/torch/replay_memory.py
+++ b/rl_2048/dqn/torch/replay_memory.py
@@ -1,17 +1,11 @@
 import random
 from collections import deque
 from collections.abc import Sequence
-from enum import Enum
 from typing import NamedTuple
 
 import torch
 
-
-class Action(Enum):
-    UP = 0
-    DOWN = 1
-    LEFT = 2
-    RIGHT = 3
+from rl_2048.dqn.common import Action
 
 
 # N: number of grids in the board

--- a/rl_2048/game_engine.py
+++ b/rl_2048/game_engine.py
@@ -2,7 +2,7 @@ from random import SystemRandom
 from typing import NamedTuple
 
 from rl_2048.common import Location
-from rl_2048.dqn.torch.replay_memory import Action
+from rl_2048.dqn.common import Action
 from rl_2048.tile import MovingGrid, Tile
 
 

--- a/tests/jax_dqn/test_dqn.py
+++ b/tests/jax_dqn/test_dqn.py
@@ -7,6 +7,7 @@ from jax import Array
 from jax import random as jrandom
 from optax import Schedule
 
+from rl_2048.dqn.common import Action
 from rl_2048.dqn.jax.dqn import DQN, TrainingParameters, create_learning_rate_fn
 from rl_2048.dqn.jax.net import (
     PREDEFINED_NETWORKS,
@@ -15,7 +16,7 @@ from rl_2048.dqn.jax.net import (
     load_predefined_net,
     train_step,
 )
-from rl_2048.dqn.jax.replay_memory import Action, Batch, Transition
+from rl_2048.dqn.jax.replay_memory import Batch, Transition
 
 
 def test_dqn():

--- a/tests/jax_dqn/test_replay_memory.py
+++ b/tests/jax_dqn/test_replay_memory.py
@@ -1,7 +1,8 @@
 import jax.random as jrandom
 from jax import Array
 
-from rl_2048.dqn.jax.replay_memory import Action, Batch, ReplayMemory, Transition
+from rl_2048.dqn.common import Action
+from rl_2048.dqn.jax.replay_memory import Batch, ReplayMemory, Transition
 
 all_memory_fields = {"states", "actions", "next_states", "rewards", "games_over"}
 

--- a/tests/test_game_engine.py
+++ b/tests/test_game_engine.py
@@ -2,7 +2,7 @@ from typing import NamedTuple
 
 import pytest
 
-from rl_2048.dqn.torch.replay_memory import Action
+from rl_2048.dqn.common import Action
 from rl_2048.game_engine import GameEngine, MoveResult
 from rl_2048.tile import Tile
 


### PR DESCRIPTION
Not necessary to redefine classes `Action`, `PolicyNetOutput`, and `TrainingParameters` in torch / JAX implementations. Move them to common.