### PR TITLE
Use flax.training impl to save/restore ckpts

### DIFF
--- a/rl_2048/dqn/jax_net.py
+++ b/rl_2048/dqn/jax_net.py
@@ -373,7 +373,7 @@ class JaxPolicyNet(PolicyNet):
         if self.training is None:
             raise ValueError(self.error_msg())
         saved_path: str = save_checkpoint(
-            ckpt_dir=model_path,
+            ckpt_dir=os.path.abspath(model_path),
             target=self.training.policy_net_train_state,
             step=self.training.step_count,
             keep=10,


### PR DESCRIPTION
Part of #17 

For now use the deprecating implementation.

Need to migrate checkpoints to orbax. I tried it but didn't succeed.